### PR TITLE
Fix build on gcc-13

### DIFF
--- a/include/orbis/module/Module.hpp
+++ b/include/orbis/module/Module.hpp
@@ -8,6 +8,7 @@
 #include "orbis-config.hpp"
 #include <cstddef>
 #include <vector>
+#include <string>
 
 namespace orbis {
 struct Thread;


### PR DESCRIPTION
On gcc 13 compilation fails because of a missing include